### PR TITLE
Github action for e2e test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,29 @@
+name: Test
+
+on: [push]
+
+jobs:
+  correctness:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.15'
+    - name: Install fluentbit
+      run: |
+        sudo chmod 0777 -R /opt
+        sudo ln -s /opt/td-agent-bit/bin/td-agent-bit /usr/local/bin/fluent-bit
+        wget https://packages.fluentbit.io/ubuntu/bionic/pool/main/t/td-agent-bit/td-agent-bit_1.5.3_amd64.deb
+        sudo dpkg -i ./td-agent-bit*.deb
+    - name: Install Tools
+      run: make install-tools
+    - name: Build
+      run: make otelcol
+    - name: Correctness
+      uses: ./
+      env:
+        TESTBED_CONFIG: testbed/tests/local.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,7 @@
+name: 'Correctness'
+description: 'Collector correctness test'
+runs:
+  using: 'composite'
+  steps:
+    - run: cd /${GITHUB_WORKSPACE-.}/${UPSTREAM_DIRECTORY}/testbed/tests && TESTBED_CONFIG=${GITHUB_WORKSPACE-.}/${WORKING_DIRECTORY}/${TESTBED_CONFIG} ./runtests.sh
+      shell: bash

--- a/testbed/correctness/traces/runtests.sh
+++ b/testbed/correctness/traces/runtests.sh
@@ -23,7 +23,8 @@ FAIL_COLOR=$(printf "\033[31mFAIL\033[0m")
 TEST_COLORIZE="${SED} 's/PASS/${PASS_COLOR}/' | ${SED} 's/FAIL/${FAIL_COLOR}/'"
 echo ${TEST_ARGS}
 mkdir -p results
-TESTBED_CONFIG=inprocess.yaml go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
+TESTBED_CONFIG=${TESTBED_CONFIG-inprocess.yaml}
+go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
 
 testStatus=${PIPESTATUS[0]}
 

--- a/testbed/tests/runtests.sh
+++ b/testbed/tests/runtests.sh
@@ -22,7 +22,8 @@ PASS_COLOR=$(printf "\033[32mPASS\033[0m")
 FAIL_COLOR=$(printf "\033[31mFAIL\033[0m")
 TEST_COLORIZE="${SED} 's/PASS/${PASS_COLOR}/' | ${SED} 's/FAIL/${FAIL_COLOR}/'"
 echo ${TEST_ARGS}
-TESTBED_CONFIG=local.yaml go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
+TESTBED_CONFIG=${TESTBED_CONFIG-local.yaml}
+go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
 
 testStatus=${PIPESTATUS[0]}
 


### PR DESCRIPTION
This adds a github action which can be run against this repository, or against another collector binary.  See https://github.com/dashpole/test-otel-distribution/pull/1 as an example of running it against another collector.